### PR TITLE
Add requirement-info-under-review status to NumberConfigStatus enum

### DIFF
--- a/src/Telnyx.net/Entities/PhoneNumbers/NumberConfigurations/NumberConfiguration.cs
+++ b/src/Telnyx.net/Entities/PhoneNumbers/NumberConfigurations/NumberConfiguration.cs
@@ -34,6 +34,8 @@
         PortedOut = 7,
         [EnumMember(Value = "port-out-pending")]
         PortOutPending = 8,
+        [EnumMember(Value = "requirement-info-under-review")]
+        RequirementInfoUnderReview = 9,
     }
 
     [JsonConverter(typeof(Newtonsoft.Json.Converters.StringEnumConverter))]


### PR DESCRIPTION
## Summary
- Adds missing `RequirementInfoUnderReview` enum value to `NumberConfigStatus`
- Fixes JSON deserialization error when API returns `"requirement-info-under-review"` status

## Test plan
- [ ] Verify deserialization succeeds when API returns `requirement-info-under-review` status

🤖 Generated with [Claude Code](https://claude.com/claude-code)