### PR TITLE
chore: bump package version to 3.1.0

### DIFF
--- a/src/Telnyx.net/Telnyx.net.csproj
+++ b/src/Telnyx.net/Telnyx.net.csproj
@@ -5,7 +5,7 @@
     <Description>Telnyx.net is a sync/async .NET Framework 4.5+ and .NETStandard 2.0 client, and a portable class library for the Telnyx API. (Official Library)</Description>
     <AssemblyTitle>Telnyx.net</AssemblyTitle>
     <VersionPrefix>25.13.0</VersionPrefix>
-    <Version>2.9.2</Version>
+    <Version>3.1.0</Version>
     <Authors>Telnyx;wildCursor</Authors>
     <TargetFrameworks>net45;netstandard2.0;net452;netstandard2.1</TargetFrameworks>
     <AssemblyName>Telnyx.net</AssemblyName>


### PR DESCRIPTION
Updates `<Version>` in Telnyx.net.csproj from 2.9.2 → 3.1.0 to match the v3.1.0 GitHub Release. NuGet package version comes from the .csproj, not git tags.